### PR TITLE
feat: add diagnostic Station sensor

### DIFF
--- a/custom_components/lun_misto_air/sensor.py
+++ b/custom_components/lun_misto_air/sensor.py
@@ -14,6 +14,7 @@ from homeassistant.const import (
     ATTR_LONGITUDE,
     CONCENTRATION_MICROGRAMS_PER_CUBIC_METER,
     PERCENTAGE,
+    EntityCategory,
     UnitOfPressure,
     UnitOfTemperature,
 )
@@ -26,6 +27,7 @@ from .const import (
     ATTR_CITY,
     ATTR_STATION_NAME,
     ATTR_UPDATED,
+    STATION_NAME_FORMAT,
     SUGGESTED_PRECISION,
 )
 from .coordinator import LUNMistoAirCoordinator
@@ -108,6 +110,16 @@ SENSOR_TYPES: tuple[LUNMistoAirSensorDescription, ...] = (
         suggested_display_precision=1,
         native_unit_of_measurement=UnitOfPressure.HPA,
         value_fn=lambda station: station.pressure / 100,
+    ),
+    LUNMistoAirSensorDescription(
+        key="station",
+        translation_key="station",
+        entity_category=EntityCategory.DIAGNOSTIC,
+        value_fn=lambda station: STATION_NAME_FORMAT.format(
+            city=station.city.capitalize(),
+            station=station.name,
+        ),
+        available_fn=lambda station: station.name is not None,
     ),
 )
 

--- a/custom_components/lun_misto_air/translations/en.json
+++ b/custom_components/lun_misto_air/translations/en.json
@@ -198,6 +198,26 @@
             "name": "Longitude"
           }
         }
+      },
+      "station": {
+        "name": "Station",
+        "state_attributes": {
+          "city": {
+            "name": "City"
+          },
+          "station_name": {
+            "name": "Station"
+          },
+          "updated": {
+            "name": "Last updated"
+          },
+          "latitude": {
+            "name": "Latitude"
+          },
+          "longitude": {
+            "name": "Longitude"
+          }
+        }
       }
     }
   }

--- a/custom_components/lun_misto_air/translations/nl.json
+++ b/custom_components/lun_misto_air/translations/nl.json
@@ -18,7 +18,6 @@
           "description": "Hoe wil je een meetstation selecteren?",
           "menu_options": {
             "map": "Selecteer een punt op de kaart",
-            "home": "Gebruik de thuislocatie van Home Assistant",
             "station_name": "Selecteer een station uit een lijst"
           }
         },
@@ -31,16 +30,6 @@
           },
           "data_description": {
             "location": "Selecteer een punt op de kaart om altijd het dichtstbijzijnde meetstation bij die locatie te krijgen",
-            "name": "Voer een naam in voor dit station"
-          }
-        },
-        "home": {
-          "title": "Gebruik de thuislocatie van Home Assistant",
-          "description": "Krijg altijd het dichtstbijzijnde meetstation bij de thuislocatie die in Home Assistant is geconfigureerd",
-          "data": {
-            "name": "Stationsnaam"
-          },
-          "data_description": {
             "name": "Voer een naam in voor dit station"
           }
         },

--- a/custom_components/lun_misto_air/translations/nl.json
+++ b/custom_components/lun_misto_air/translations/nl.json
@@ -198,6 +198,26 @@
             "name": "Lengtegraad"
           }
         }
+      },
+      "station": {
+        "name": "Station",
+        "state_attributes": {
+          "city": {
+            "name": "Stad"
+          },
+          "station_name": {
+            "name": "Station"
+          },
+          "updated": {
+            "name": "Laatst bijgewerkt"
+          },
+          "latitude": {
+            "name": "Breedtegraad"
+          },
+          "longitude": {
+            "name": "Lengtegraad"
+          }
+        }
       }
     }
   }

--- a/custom_components/lun_misto_air/translations/nl.json
+++ b/custom_components/lun_misto_air/translations/nl.json
@@ -1,0 +1,215 @@
+{
+  "title": "LUN Misto Air",
+  "config": {
+    "step": {
+      "user": {
+        "description": "Stel LUN Misto Air in om luchtkwaliteitsmeetstations te integreren."
+      }
+    },
+    "abort": {
+      "already_configured": "Er kan slechts één LUN Misto Air-integratie worden geconfigureerd."
+    }
+  },
+  "config_subentries": {
+    "station": {
+      "step": {
+        "user": {
+          "title": "Meetstation toevoegen",
+          "description": "Hoe wil je een meetstation selecteren?",
+          "menu_options": {
+            "map": "Selecteer een punt op de kaart",
+            "home": "Gebruik de thuislocatie van Home Assistant",
+            "station_name": "Selecteer een station uit een lijst"
+          }
+        },
+        "map": {
+          "title": "Selecteer een punt op de kaart",
+          "description": "Selecteer een punt op de kaart om altijd het dichtstbijzijnde meetstation bij die locatie te krijgen",
+          "data": {
+            "location": "Locatie",
+            "name": "Stationsnaam"
+          },
+          "data_description": {
+            "location": "Selecteer een punt op de kaart om altijd het dichtstbijzijnde meetstation bij die locatie te krijgen",
+            "name": "Voer een naam in voor dit station"
+          }
+        },
+        "home": {
+          "title": "Gebruik de thuislocatie van Home Assistant",
+          "description": "Krijg altijd het dichtstbijzijnde meetstation bij de thuislocatie die in Home Assistant is geconfigureerd",
+          "data": {
+            "name": "Stationsnaam"
+          },
+          "data_description": {
+            "name": "Voer een naam in voor dit station"
+          }
+        },
+        "station_name": {
+          "title": "Selecteer een station uit de lijst",
+          "description": "Selecteer een meetstation uit de lijst",
+          "data": {
+            "station_name": "Naam van het meetstation",
+            "name": "Stationsnaam"
+          },
+          "data_description": {
+            "station_name": "Je kunt de naam van het meetstation vinden op: {lun_url}",
+            "name": "Voer een naam in voor dit station"
+          }
+        }
+      },
+      "error": {
+        "no_stations": "Geen stations gevonden",
+        "cannot_find_station": "Kan het dichtstbijzijnde station niet vinden"
+      },
+      "abort": {
+        "already_configured": "Dit station is al geconfigureerd."
+      },
+      "initiate_flow": {
+        "user": "Meetstation toevoegen"
+      },
+      "entry_type": "Meetstation"
+    }
+  },
+  "device": {
+    "lun_misto_air": {
+      "name": "LUN Misto Air {name}"
+    }
+  },
+  "entity": {
+    "sensor": {
+      "aqi": {
+        "state_attributes": {
+          "city": {
+            "name": "Stad"
+          },
+          "station_name": {
+            "name": "Station"
+          },
+          "updated": {
+            "name": "Laatst bijgewerkt"
+          },
+          "latitude": {
+            "name": "Breedtegraad"
+          },
+          "longitude": {
+            "name": "Lengtegraad"
+          }
+        }
+      },
+      "pm1": {
+        "state_attributes": {
+          "city": {
+            "name": "Stad"
+          },
+          "station_name": {
+            "name": "Station"
+          },
+          "updated": {
+            "name": "Laatst bijgewerkt"
+          },
+          "latitude": {
+            "name": "Breedtegraad"
+          },
+          "longitude": {
+            "name": "Lengtegraad"
+          }
+        }
+      },
+      "pm10": {
+        "state_attributes": {
+          "city": {
+            "name": "Stad"
+          },
+          "station_name": {
+            "name": "Station"
+          },
+          "updated": {
+            "name": "Laatst bijgewerkt"
+          },
+          "latitude": {
+            "name": "Breedtegraad"
+          },
+          "longitude": {
+            "name": "Lengtegraad"
+          }
+        }
+      },
+      "pm25": {
+        "state_attributes": {
+          "city": {
+            "name": "Stad"
+          },
+          "station_name": {
+            "name": "Station"
+          },
+          "updated": {
+            "name": "Laatst bijgewerkt"
+          },
+          "latitude": {
+            "name": "Breedtegraad"
+          },
+          "longitude": {
+            "name": "Lengtegraad"
+          }
+        }
+      },
+      "temperature": {
+        "state_attributes": {
+          "city": {
+            "name": "Stad"
+          },
+          "station_name": {
+            "name": "Station"
+          },
+          "updated": {
+            "name": "Laatst bijgewerkt"
+          },
+          "latitude": {
+            "name": "Breedtegraad"
+          },
+          "longitude": {
+            "name": "Lengtegraad"
+          }
+        }
+      },
+      "humidity": {
+        "state_attributes": {
+          "city": {
+            "name": "Stad"
+          },
+          "station_name": {
+            "name": "Station"
+          },
+          "updated": {
+            "name": "Laatst bijgewerkt"
+          },
+          "latitude": {
+            "name": "Breedtegraad"
+          },
+          "longitude": {
+            "name": "Lengtegraad"
+          }
+        }
+      },
+      "pressure": {
+        "state_attributes": {
+          "city": {
+            "name": "Stad"
+          },
+          "station_name": {
+            "name": "Station"
+          },
+          "updated": {
+            "name": "Laatst bijgewerkt"
+          },
+          "latitude": {
+            "name": "Breedtegraad"
+          },
+          "longitude": {
+            "name": "Lengtegraad"
+          }
+        }
+      }
+    }
+  }
+}

--- a/custom_components/lun_misto_air/translations/uk.json
+++ b/custom_components/lun_misto_air/translations/uk.json
@@ -198,6 +198,26 @@
             "name": "Довгота"
           }
         }
+      },
+      "station": {
+        "name": "Станція",
+        "state_attributes": {
+          "city": {
+            "name": "Місто"
+          },
+          "station_name": {
+            "name": "Станція"
+          },
+          "updated": {
+            "name": "Востаннє оновлено"
+          },
+          "latitude": {
+            "name": "Широта"
+          },
+          "longitude": {
+            "name": "Довгота"
+          }
+        }
       }
     }
   }


### PR DESCRIPTION
## Summary

Adds a **diagnostic `Station` sensor** that exposes which measuring station is currently used, formatted as `{City} ({station})` (e.g. `Kyiv (135)`).

This makes the active station visible directly on the device page ("Service Info") — especially useful for **dynamic** (nearest-station) subentries, where the underlying station can change over time and was previously only visible as a per-sensor attribute.

## Changes

- `sensor.py`: new `LUNMistoAirSensorDescription` with `key="station"`, `entity_category=DIAGNOSTIC`, value from `STATION_NAME_FORMAT`.
- `translations/en.json`, `uk.json`, `nl.json`: added `station` entity name + attribute labels. Key structure stays identical across all locales.

## Validation

- `ruff check` on the whole integration: passed.
- Smoke test in the official `ghcr.io/home-assistant/home-assistant:2026.2` Docker image: module imports cleanly and the `station` sensor returns `Kyiv (135)` with category `diagnostic`.

> Note: stacked on top of #58 (Dutch translation), so the diff includes `nl.json`. Rebase after #58 merges.



Closes #60
