### PR TITLE
feat: mark weather sensors unavailable when station sensor offline

### DIFF
--- a/custom_components/lun_misto_air/const.py
+++ b/custom_components/lun_misto_air/const.py
@@ -28,3 +28,11 @@ ATTR_UPDATED: Final = "updated"
 # Consts
 UPDATE_INTERVAL: Final = 10
 SUGGESTED_PRECISION: Final = 3
+
+# Plausible ranges used to detect offline/erroneous sensor readings.
+# The API reports 0 (or physically impossible values) when a sensor is
+# offline or missing, instead of omitting the field.
+MIN_PRESSURE_PA: Final = 80000
+MAX_PRESSURE_PA: Final = 110000
+MIN_HUMIDITY: Final = 0
+MAX_HUMIDITY: Final = 100

--- a/custom_components/lun_misto_air/sensor.py
+++ b/custom_components/lun_misto_air/sensor.py
@@ -26,6 +26,10 @@ from .const import (
     ATTR_CITY,
     ATTR_STATION_NAME,
     ATTR_UPDATED,
+    MAX_HUMIDITY,
+    MAX_PRESSURE_PA,
+    MIN_HUMIDITY,
+    MIN_PRESSURE_PA,
     SUGGESTED_PRECISION,
 )
 from .coordinator import LUNMistoAirCoordinator
@@ -33,6 +37,21 @@ from .data import LUNMistoAirConfigEntry
 from .entity import LUNMistoAirEntity
 
 LOGGER = logging.getLogger(__name__)
+
+
+def _weather_block_offline(station: LUNMistoAirStation) -> bool:
+    """Return True when the whole weather block is offline (all zero)."""
+    return station.temperature == 0 and station.humidity == 0 and station.pressure == 0
+
+
+def _humidity_available(station: LUNMistoAirStation) -> bool:
+    """Return True when humidity is within a plausible range."""
+    return MIN_HUMIDITY < station.humidity <= MAX_HUMIDITY
+
+
+def _pressure_available(station: LUNMistoAirStation) -> bool:
+    """Return True when pressure is within a plausible range."""
+    return MIN_PRESSURE_PA <= station.pressure <= MAX_PRESSURE_PA
 
 
 @dataclass(frozen=True, kw_only=True)
@@ -90,6 +109,7 @@ SENSOR_TYPES: tuple[LUNMistoAirSensorDescription, ...] = (
         suggested_display_precision=1,
         native_unit_of_measurement=UnitOfTemperature.CELSIUS,
         value_fn=lambda station: station.temperature,
+        available_fn=lambda station: not _weather_block_offline(station),
     ),
     LUNMistoAirSensorDescription(
         key="humidity",
@@ -99,6 +119,7 @@ SENSOR_TYPES: tuple[LUNMistoAirSensorDescription, ...] = (
         suggested_display_precision=0,
         native_unit_of_measurement=PERCENTAGE,
         value_fn=lambda station: station.humidity,
+        available_fn=_humidity_available,
     ),
     LUNMistoAirSensorDescription(
         key="pressure",
@@ -108,6 +129,7 @@ SENSOR_TYPES: tuple[LUNMistoAirSensorDescription, ...] = (
         suggested_display_precision=1,
         native_unit_of_measurement=UnitOfPressure.HPA,
         value_fn=lambda station: station.pressure / 100,
+        available_fn=_pressure_available,
     ),
 )
 


### PR DESCRIPTION
## Summary

Adds availability checks so `temperature`, `humidity` and `pressure` sensors report **unavailable** when a station's sensor is offline, instead of showing misleading values.

The API returns `0` (or physically impossible values) for offline/missing sensors rather than omitting the field.

## Changes

- `const.py`: plausible-range constants (`MIN/MAX_PRESSURE_PA`, `MIN/MAX_HUMIDITY`).
- `sensor.py`: `available_fn` for the three weather sensors via small helpers:
  - `pressure`: available within `80000–110000 Pa` (catches `0` and absurd values like `156253 Pa`).
  - `humidity`: available within `0 < humidity <= 100`.
  - `temperature`: unavailable only when the whole weather block is `0` (temp+humidity+pressure), so a genuine 0 °C reading is never hidden.

## Validation

- `ruff check` on the whole integration: passed.
- Smoke test in the official `ghcr.io/home-assistant/home-assistant:2026.2` Docker image: 11 edge cases (healthy, `pressure=0`, absurd pressure, all-zero block, `humidity=0`, `humidity=100` boundary) all pass.

Closes #61
