### PR TITLE
[codex] Enforce one config entry

### DIFF
--- a/custom_components/lun_misto_air/manifest.json
+++ b/custom_components/lun_misto_air/manifest.json
@@ -3,10 +3,10 @@
   "name": "LUN Misto Air",
   "codeowners": ["@denysdovhan"],
   "config_flow": true,
-  "single_config_entry": true,
   "documentation": "https://github.com/denysdovhan/ha-lun-misto-air",
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/denysdovhan/ha-lun-misto-air",
   "requirements": [],
+  "single_config_entry": true,
   "version": "0.0.0-unreleased"
 }

--- a/custom_components/lun_misto_air/manifest.json
+++ b/custom_components/lun_misto_air/manifest.json
@@ -3,6 +3,7 @@
   "name": "LUN Misto Air",
   "codeowners": ["@denysdovhan"],
   "config_flow": true,
+  "single_config_entry": true,
   "documentation": "https://github.com/denysdovhan/ha-lun-misto-air",
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/denysdovhan/ha-lun-misto-air",


### PR DESCRIPTION
## Why

LUN Misto Air supports one top-level configuration entry. Individual air-quality stations are managed as config subentries, and the config flow already rejects a second root entry. Without the manifest declaration, Home Assistant can still initialize another add flow before the integration performs its own duplicate check.

## What changed

Set `single_config_entry` to `true` in the integration manifest. Home Assistant now enforces the existing single-root-entry architecture through its standard config-flow handling while continuing to allow multiple station subentries.

## Validation

- `scripts/lint`
- `uv run pre-commit run --files custom_components/lun_misto_air/manifest.json`

